### PR TITLE
Make kerberos keytab management more flexible

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -62,6 +62,9 @@ The following parameters are available in the `realmd` class:
 * [`required_packages`](#-realmd--required_packages)
 * [`extra_join_options`](#-realmd--extra_join_options)
 * [`computer_name`](#-realmd--computer_name)
+* [`manage_krb_keytab`](#-realmd--manage_krb_keytab)
+* [`krb_keytab_source`](#-realmd--krb_keytab_source)
+* [`krb_keytab_content`](#-realmd--krb_keytab_content)
 
 ##### <a name="-realmd--realmd_package_name"></a>`realmd_package_name`
 
@@ -260,6 +263,37 @@ Extra arguments passed to realm join command
 Data type: `Variant[String[1, 15], Undef, Boolean[false]]`
 
 The computer name used with password join
+
+##### <a name="-realmd--manage_krb_keytab"></a>`manage_krb_keytab`
+
+Data type: `Boolean`
+
+Whether to manage keytab file
+
+Default value: `true`
+
+##### <a name="-realmd--krb_keytab_source"></a>`krb_keytab_source`
+
+Data type: `Optional[String[1]]`
+
+Keytab file source
+
+Default value: `undef`
+
+##### <a name="-realmd--krb_keytab_content"></a>`krb_keytab_content`
+
+Data type:
+
+```puppet
+Optional[Variant[
+      Binary, Sensitive[Binary],
+      String[1], Sensitive[String[1]],
+  ]]
+```
+
+Keytab file content. If defined, must be either a strict-base64-encoded String or a Binary stream.
+
+Default value: `undef`
 
 ### <a name="realmd--config"></a>`realmd::config`
 

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,13 +1,15 @@
 ---
 realmd::krb_client_package_name: krb5-user
 realmd::required_packages:
-  sssd-tools:
+  libnss-sss:
     ensure: installed
   libpam-modules:
     ensure: installed
-  libnss-sss:
-    ensure: installed
   libpam-sss:
     ensure: installed
+  packagekit:
+    ensure: installed
   samba-common-bin:
+    ensure: installed
+  sssd-tools:
     ensure: installed

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,7 +16,7 @@ realmd::sssd_config_cache_file: /var/lib/sss/db/config.ldb
 realmd::manage_sssd_config: false
 realmd::manage_sssd_service: true
 realmd::manage_sssd_package: true
-realmd::domain: "%{::domain}"
+realmd::domain: "%{facts.networking.domain}"
 realmd::domain_join_user: ~
 realmd::domain_join_password: ~
 realmd::one_time_password: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,12 @@
 #   Extra arguments passed to realm join command
 # @param computer_name
 #   The computer name used with password join
+# @param manage_krb_keytab
+#   Whether to manage keytab file
+# @param krb_keytab_source
+#   Keytab file source
+# @param krb_keytab_content
+#   Keytab file content. If defined, must be either a strict-base64-encoded String or a Binary stream.
 #
 class realmd (
   String $realmd_package_name,
@@ -99,6 +105,12 @@ class realmd (
   Hash $required_packages,
   Variant[Array, Undef] $extra_join_options,
   Variant[String[1, 15], Undef, Boolean[false]] $computer_name,
+  Boolean $manage_krb_keytab = true,
+  Optional[Variant[
+      Binary, Sensitive[Binary],
+      String[1], Sensitive[String[1]],
+  ]] $krb_keytab_content = undef,
+  Optional[String[1]] $krb_keytab_source = undef,
 ) {
   if $krb_ticket_join == false {
     if ($domain_join_user and !$domain_join_password) {

--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -11,15 +11,34 @@ class realmd::join::keytab {
   $_krb_config        = $realmd::krb_config
   $_manage_krb_config = $realmd::manage_krb_config
   $_ou                = $realmd::ou
+  $_manage_keytab     = $realmd::manage_krb_keytab
+  $_keytab_source     = $realmd::krb_keytab_source
+  $_keytab_content    = $realmd::krb_keytab_content
 
   $_krb_config_final = deep_merge({ 'libdefaults' => { 'default_realm' => upcase($facts['networking']['domain']) } }, $_krb_config)
 
-  file { 'krb_keytab':
-    path   => $_krb_keytab,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0400',
-    before => Exec['run_kinit_with_keytab'],
+  # Expect the String to hold a base64-encoded keytab contents
+  # lint:ignore:unquoted_string_in_selector
+  $_real_keytab_content = $_keytab_content ? {
+    String            => Binary($_keytab_content, '%B'),
+    Sensitive[String] => Binary($_keytab_content.unwrap, '%B'),
+    Binary            => $_keytab_content,
+    Sensitive[Binary] => $_keytab_content.unwrap,
+    default           => undef,
+  }
+  # lint:endignore:unquoted_string_in_selector
+
+  if $_manage_keytab {
+    file { 'krb_keytab':
+      path      => $_krb_keytab,
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0400',
+      source    => $_keytab_source,
+      content   => $_real_keytab_content,
+      show_diff => false,
+      before    => Exec['run_kinit_with_keytab'],
+    }
   }
 
   if $_manage_krb_config {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -15,25 +15,26 @@ describe 'realmd' do
           packages = case os_facts[:os]['family']
                      when 'Debian'
                        [
-                         'realmd',
-                         'sssd',
                          'adcli',
                          'krb5-user',
-                         'sssd-tools',
-                         'libpam-modules',
                          'libnss-sss',
+                         'libpam-modules',
                          'libpam-sss',
+                         'packagekit',
+                         'realmd',
                          'samba-common-bin',
+                         'sssd',
+                         'sssd-tools',
                        ]
                      when 'RedHat'
                        [
-                         'realmd',
-                         'sssd',
                          'adcli',
                          'krb5-workstation',
                          'oddjob',
                          'oddjob-mkhomedir',
+                         'realmd',
                          'samba-common-tools',
+                         'sssd',
                        ]
                      end
 


### PR DESCRIPTION
It's now possible to provide source or content for the keytab file in the module parameters. Also it's now possible to tell the module to not manage the keytab at all.

Fixes #4 