### PR TITLE
Remove special "computer name" logic for RHEL when doing join by pass…

### DIFF
--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -22,10 +22,7 @@ class realmd::join::password {
       'jammy'   => '',
       default => ["--computer-name=${_computer_name}"],
     }
-  } elsif ($facts['os']['family'] == 'RedHat' and Integer($facts['os']['release']['major']) >= 8) {
-    $_computer_name_arg = ''
-  }
-  else {
+  } else {
     $_computer_name_arg = ["--computer-name=${_computer_name}"]
   }
 

--- a/spec/classes/join__password_spec.rb
+++ b/spec/classes/join__password_spec.rb
@@ -22,11 +22,7 @@ describe 'realmd' do
               facts.dig(:os, 'distro', 'id') == 'Ubuntu' &&
               ['focal', 'jammy'].include?(facts.dig(:os, 'distro', 'codename'))
             )
-            is_el8_or_higher = (
-              facts.dig(:os, 'family') == 'RedHat' &&
-              facts.dig(:os, 'release', 'major').to_i >= 8
-            )
-            is_ubuntu_20 || is_el8_or_higher
+            is_ubuntu_20
           end
 
           it { is_expected.to contain_class('realmd::join::password') }


### PR DESCRIPTION
Considering that

* I can confirm that I've been personally using this modification with RHEL since at least as far back as 8.1 with no issues
* I could find no reports of bugs related to `realmd` and `--computer-name` related to RHEL 8+
* RHEL is not officially supported by this module as of a5a6f72

I made a simple modification to cease any special handling of `--computer-name` for RHEL at all